### PR TITLE
Post, Comment 수정, 삭제 보안 강화 및 NotFoundException 추가

### DIFF
--- a/src/main/java/com/example/jolvre/common/error/ErrorCode.java
+++ b/src/main/java/com/example/jolvre/common/error/ErrorCode.java
@@ -19,7 +19,11 @@ public enum ErrorCode {
     //Diary
     DIARY_NOT_FOUND("D01", "Diary is not found", HttpStatus.BAD_REQUEST.value()),
     //Group Exhibit
-    GROUP_EXHIBIT_NOT_FOUND("G01", "Group Exhibit is not found", HttpStatus.BAD_REQUEST.value());
+    GROUP_EXHIBIT_NOT_FOUND("G01", "Group Exhibit is not found", HttpStatus.BAD_REQUEST.value()),
+    //Post
+    POST_NOT_FOUND("P01", "Post is not found", HttpStatus.BAD_REQUEST.value()),
+    //Comment
+    COMMENT_NOT_FOUND("C01", "Comment is not found", HttpStatus.BAD_REQUEST.value());
     private final String code;
     private final String message;
     private final int status;

--- a/src/main/java/com/example/jolvre/common/error/comment/CommentNotFoundException.java
+++ b/src/main/java/com/example/jolvre/common/error/comment/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.jolvre.common.error.comment;
+
+import com.example.jolvre.common.error.EntityNotFoundException;
+import com.example.jolvre.common.error.ErrorCode;
+
+public class CommentNotFoundException extends EntityNotFoundException {
+    public CommentNotFoundException() {
+        super(ErrorCode.COMMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/jolvre/common/error/post/PostNotFoundException.java
+++ b/src/main/java/com/example/jolvre/common/error/post/PostNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.jolvre.common.error.post;
+
+import com.example.jolvre.common.error.EntityNotFoundException;
+import com.example.jolvre.common.error.ErrorCode;
+
+public class PostNotFoundException extends EntityNotFoundException {
+    public PostNotFoundException() {
+        super(ErrorCode.POST_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/jolvre/post/api/CommentController.java
+++ b/src/main/java/com/example/jolvre/post/api/CommentController.java
@@ -59,6 +59,6 @@ public class CommentController {
     @Operation(summary = "댓글 삭제")
     public void deleteComment(@PathVariable("commentId") Long commentId,
                               @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        commentService.deleteComment(commentId);
+        commentService.deleteComment(commentId, principalDetails.getUser());
     }
 }

--- a/src/main/java/com/example/jolvre/post/api/PostController.java
+++ b/src/main/java/com/example/jolvre/post/api/PostController.java
@@ -93,7 +93,6 @@ public class PostController {
     }
 
     //키워드 검색
-    //미구현
     @Operation(summary = "제목 키워드 (str)로 검색")
     @GetMapping
     public Page<postResponse> searchByKeyword(@RequestParam("keyword") String keyword,

--- a/src/main/java/com/example/jolvre/post/api/PostController.java
+++ b/src/main/java/com/example/jolvre/post/api/PostController.java
@@ -54,14 +54,13 @@ public class PostController {
     @Operation(summary = "유저의 게시글 조회")
     @GetMapping("/user/{userId}")
     public ResponseEntity<Page<postResponse>> getPostsByUserId(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable("userId") Long userId,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             Pageable pageable) {
 
         pageable = PageRequest.of(page - 1, size, Sort.by("createdDate").descending());
-        Page<postResponse> postList = postService.getPostsByUserId(principalDetails.getUser().getId(),
-                (PageRequest) pageable);
+        Page<postResponse> postList = postService.getPostsByUserId(userId, (PageRequest) pageable);
 
         return ResponseEntity.status(HttpStatus.OK).body(postList);
     }
@@ -95,7 +94,7 @@ public class PostController {
     //키워드 검색
     @Operation(summary = "제목 키워드 (str)로 검색")
     @GetMapping
-    public Page<postResponse> searchByKeyword(@RequestParam("keyword") String keyword,
+    public Page<postResponse> searchByKeyword(@RequestParam(value = "keyword") String keyword,
                                               @RequestParam(value = "page", defaultValue = "1") int page,
                                               @RequestParam(value = "size", defaultValue = "10") int size,
                                               Pageable pageable) {

--- a/src/main/java/com/example/jolvre/post/api/PostController.java
+++ b/src/main/java/com/example/jolvre/post/api/PostController.java
@@ -78,7 +78,7 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public void deletePost(@PathVariable("postId") Long postId,
                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        postService.deletePost(postId);
+        postService.deletePost(postId, principalDetails.getUser());
     }
 
     //특정 게시글 수정

--- a/src/main/java/com/example/jolvre/post/service/PostService.java
+++ b/src/main/java/com/example/jolvre/post/service/PostService.java
@@ -12,6 +12,8 @@ import com.example.jolvre.user.entity.User;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -113,6 +115,7 @@ public class PostService {
         log.info("[post] : {} 게시글 수정 완료", request.getTitle());
     }
 
+    @Transactional
     public Page<postResponse> searchByKeyword(String keyword, Pageable pageable) {
         Page<Post> postList = postRepository.findByTitleContaining(keyword, pageable);
         return postList.map(postResponse::toDTO);

--- a/src/main/java/com/example/jolvre/post/service/PostService.java
+++ b/src/main/java/com/example/jolvre/post/service/PostService.java
@@ -1,6 +1,9 @@
 package com.example.jolvre.post.service;
 
 import com.amazonaws.util.CollectionUtils;
+import com.example.jolvre.common.error.post.PostNotFoundException;
+import com.example.jolvre.common.error.user.UserAccessDeniedException;
+import com.example.jolvre.common.error.user.UserNotFoundException;
 import com.example.jolvre.common.service.S3Service;
 import com.example.jolvre.post.dto.postRequest;
 import com.example.jolvre.post.dto.postResponse;
@@ -11,8 +14,9 @@ import com.example.jolvre.post.repository.PostRepository;
 import com.example.jolvre.user.entity.User;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
+import com.example.jolvre.user.repository.UserRepository;
+import com.example.jolvre.user.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +29,6 @@ import org.springframework.stereotype.Service;
 
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 @Service
 @Builder
@@ -38,6 +38,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final S3Service s3Service;
     private final PostImageRepository postImageRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
 
     public void upload(postRequest request, User loginuser) {
         Post post = new Post();
@@ -70,49 +72,69 @@ public class PostService {
     }
 
     public Page<postResponse> getPostsByUserId(Long userId, PageRequest pageable) {
-        log.info("[post] : {}의 모든 게시글 조회", userId);
-
-        Page<Post> postList = postRepository.findAllByUserId(userId, pageable);
-        return postList.map(postResponse::toDTO);
+        if (userRepository.findById(userId).isEmpty()) {
+            throw new UserNotFoundException();
+        }
+        else{
+            Page<Post> postList = postRepository.findAllByUserId(userId, pageable);
+            log.info("[post] : {}의 모든 게시글 조회", userId);
+            return postList.map(postResponse::toDTO);
+        }
     }
 
     public postResponse getPostById(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("Does not exist"));
+                .orElseThrow(PostNotFoundException::new);
 
         log.info("[post] : {} 불러오기", Objects.requireNonNull(post).getTitle());
         return postResponse.toDTO(post);
     }
 
-    public void deletePost(Long postId) {
-        postRepository.deleteById(postId);
-        log.info("[post] : {} 게시글 삭제 완료", postId);
+    public void deletePost(Long postId, User user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+
+        if (!Objects.equals(post.getUser().getId(), user.getId()))
+        {
+            log.info("[post] : 게시글 삭제 권한이 없습니다");
+            throw new UserAccessDeniedException();
+        }
+        else {
+            postRepository.deleteById(postId);
+            log.info("[post] : {} 게시글 삭제 완료", postId);
+        }
     }
 
     public void updatePost(postRequest request, Long postId, User loginuser) {
         Post existingPost = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("Post not found with id: " + postId));
+                .orElseThrow(PostNotFoundException::new);
 
-        existingPost.setTitle(request.getTitle());
-        existingPost.setContent(request.getContent());
+        //로그인 한 유저가 해당 게시글의 글쓴이일때만 수정 가능
+        if (!Objects.equals(existingPost.getUser().getId(), loginuser.getId())) {
+            log.info("[post] : 게시글 수정 권한이 없습니다");
+            throw new UserAccessDeniedException();
+        } else {
+            existingPost.setTitle(request.getTitle());
+            existingPost.setContent(request.getContent());
 
-        //List<MultipartFile>이 비어있지 않을 때만 s3에 이미지 저장
-        if (!CollectionUtils.isNullOrEmpty(request.getImages())) {
-            List<PostImage> postImages = new ArrayList<>();
-            s3Service.uploadImages(request.getImages()).forEach(
-                    url -> {
-                        PostImage postImage = PostImage.builder().url(url).build();
-                        existingPost.addImage(postImage);
-                        postImages.add(postImage);
-                    }
-            );
-            postRepository.save(existingPost);
-            postImageRepository.saveAll(postImages);
+            //List<MultipartFile>이 비어있지 않을 때만 s3에 이미지 저장
+            if (!CollectionUtils.isNullOrEmpty(request.getImages())) {
+                List<PostImage> postImages = new ArrayList<>();
+                s3Service.uploadImages(request.getImages()).forEach(
+                        url -> {
+                            PostImage postImage = PostImage.builder().url(url).build();
+                            existingPost.addImage(postImage);
+                            postImages.add(postImage);
+                        }
+                );
+                postRepository.save(existingPost);
+                postImageRepository.saveAll(postImages);
+            }
+            else
+                postRepository.save(existingPost);
+
+            log.info("[post] : {} 게시글 수정 완료", request.getTitle());
         }
-        else
-            postRepository.save(existingPost);
-
-        log.info("[post] : {} 게시글 수정 완료", request.getTitle());
     }
 
     @Transactional
@@ -123,7 +145,7 @@ public class PostService {
 
     public void updateViews(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("Post does not found with id : " + postId));
+                .orElseThrow(PostNotFoundException::new);
         post.setView(post.getView() + 1);
         postRepository.save(post);
     }


### PR DESCRIPTION
각 유저가 소유한 게시글, 댓글이 아닐 경우 수정, 삭제가 불가능 하게끔 변경.
Post, Comment NotFoundException 에러코드 추가.

+

api/v1/post/user/{userId}를 통해 {userId}의 모든 글 확인하는 기능 정상 작동하게끔 수정
제목 키워드 검색 기능 추가.